### PR TITLE
fixing zst flags

### DIFF
--- a/startup.sh
+++ b/startup.sh
@@ -101,7 +101,7 @@ elif [[ "$InputFile" == *.zst ]]; then
         exit 1
     fi
     TEMP_UNZIPPED="${WORKING_DIR}/$(basename "${InputFile%.zst}")"
-    zstd -d -c "$InputFile" > "$TEMP_UNZIPPED"
+    zstd --memory=2048MB -d -c "$InputFile" > "$TEMP_UNZIPPED"
     DECOMPRESS_STATUS=$?
 fi
 


### PR DESCRIPTION
Patch for error: 

Detected zstd compressed input file. Decompressing...
elab-v0.3.0.json.zst : Decoding error (36) : Frame requires too much memory for decoding
elab-v0.3.0.json.zst : Window size larger than maximum : 2147483648 > 134217728
elab-v0.3.0.json.zst : Use --long=31 or --memory=2048MB
Error: Failed to decompress '/mnt/repo/spoke-genelab-kg/main/spoke-genelab-v0.3.0.json.zst'.