### PR TITLE
Handle absence of 'prefixes' in conf

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -137,7 +137,8 @@ def asURI(text, conf, default_base, class_labels=[]):
             base = conf['prefixes'][pieces[0]]
             return f"{base}{pieces[1]}"
         else:
-            return f"{default_base}{text}".replace('<','%3c').replace('>','%3e')
+            escaped_text = text.replace('<','%3c').replace('>','%3e')
+            return f"{default_base}{escaped_text}"
     elif not any(c.isspace() for c in text):
         base = next(
             (conf['mappings'][label]['base'] for label in class_labels if label in conf['mappings'] and 'base' in conf['mappings'][label]),

--- a/src/main.py
+++ b/src/main.py
@@ -133,9 +133,11 @@ def asURI(text, conf, default_base, class_labels=[]):
         return conf['mappings'][text]['iri']
     elif not any(c.isspace() for c in text) and ":" in text:
         pieces = text.split(":", maxsplit=1)
-        if conf['prefixes'][pieces[0]]:
+        if 'prefixes' in conf and pieces[0] in conf['prefixes']:
             base = conf['prefixes'][pieces[0]]
             return f"{base}{pieces[1]}"
+        else:
+            return f"{default_base}{text}".replace('<','%3c').replace('>','%3e')
     elif not any(c.isspace() for c in text):
         base = next(
             (conf['mappings'][label]['base'] for label in class_labels if label in conf['mappings'] and 'base' in conf['mappings'][label]),

--- a/tests/test-config/example3.yaml
+++ b/tests/test-config/example3.yaml
@@ -1,0 +1,6 @@
+base: 'https://purl.org/okn/frink/kg/nasa-gesdisc/'
+mappings:
+  doi:
+    type: 'IRI'
+    iri: 'http://purl.org/ontology/bibo/doi'
+    base: 'http://dx.doi.org/'

--- a/tests/test-json/example3.json
+++ b/tests/test-json/example3.json
@@ -1,0 +1,2 @@
+{"type":"node","id":"24890","labels":["Publication"],"properties":{"doi":"10.57890/VIEMILIEU/2024.74-1/2:1-44"}}
+{"type":"node","id":"65441","labels":["Publication"],"properties":{"doi":"10.1175/1525-7541(2002)003<0660:EOFDFC>2.0.CO;2"}}

--- a/tests/test-rdf/example3.ttl
+++ b/tests/test-rdf/example3.ttl
@@ -1,0 +1,10 @@
+@prefix bibo: <http://purl.org/ontology/bibo/> .
+@prefix node: <https://purl.org/okn/frink/kg/nasa-gesdisc/node/> .
+@prefix schema: <https://purl.org/okn/frink/kg/nasa-gesdisc/schema/> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+node:24890 a schema:Publication .
+node:24890 bibo:doi <http://dx.doi.org/10.57890/VIEMILIEU/2024.74-1/2:1-44> .
+
+node:65441 a schema:Publication .
+node:65441 bibo:doi <http://dx.doi.org/10.1175/1525-7541(2002)003%3c0660:EOFDFC%3e2.0.CO;2> .


### PR DESCRIPTION
When working with the NASA-GESDISC graph it was discovered that due to DOIs containing colons, they were mistakenly being decomposed as CURIEs, which led to issues if prefixes weren't defined in the configuration.

It was also discovered that DOIs containing < and > also caused RDF serialization of the resulting IRIs to fail, so it also escapes those signs in that case.